### PR TITLE
missing "not" in sentence explanation on how to abstain

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -115,7 +115,7 @@
 
     <p>If the YES address receives any ETH from an address, then all the ETH under this address will be considered as a batch of votes that goes to YES.</p>
     <p>If later this address makes a transaction to the NO address, then the entire batch of votes will be recounted as NO.</p>
-    <p>If voters who after voting, decide to abstain from this vote, they can move the ETH to an address that has yet participated in this vote.</p>
+    <p>If voters who after voting, decide to abstain from this vote, they can move the ETH to an address that has not yet participated in this vote.</p>
 
     <p><strong>4. Ballot counting: </strong>Dynamic real-time counting of the ETH under the wallet addresses that have voted.</p>
     <p><strong>5. Fund Security: </strong>No ETH are collected or locked.</p>


### PR DESCRIPTION
it looks that in http://carbonvote.com the sentence
`If voters who after voting, decide to abstain from this vote, they can move the ETH to an address that has yet participated in this vote.` is missing a `not`.
